### PR TITLE
fix vertically center the cursor (isue #9): use 'suffixIcon' instead of 'suffix'

### DIFF
--- a/lib/_shared/widgets/message_box_widget.dart
+++ b/lib/_shared/widgets/message_box_widget.dart
@@ -29,7 +29,7 @@ class _MessageBoxState extends State<MessageBox> {
                 borderSide:
                     const BorderSide(color: Colors.black38, width: 1.0)),
             contentPadding: const EdgeInsets.symmetric(horizontal: 12.0),
-            suffix: IconButton(
+            suffixIcon: IconButton(
               onPressed: () {
                 widget.onSendMessage(_controller.text);
                 _controller.text = '';


### PR DESCRIPTION
**Suffix** is a generic widget, Flutter doesn't automatically handle its alignment and padding like it does with suffixIcon.
**SuffixIcon** is placed within a fixed-size area reserved for icons, ensuring that it doesn’t disrupt the layout of the TextField or affect the size of the widget.

_The suffix widget is positioned relative to the text in the TextField, and its size might affect the vertical alignment of the text and the cursor.
The widget you place inside suffix could increase the height of the TextField because Flutter tries to fit the entire widget inside the layout, causing misalignment in some cases._